### PR TITLE
Adjust nav line-height to avoid text overlap

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,8 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+nav ul li {
+  line-height: 12px;
+}


### PR DESCRIPTION
This PR adds custom CSS (following instructions at https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll), reducing `line-height` for items in the left nav list from `16px` to `12px`. This change should fix the issue reported by @MaryDeWittDia:

![image001](https://user-images.githubusercontent.com/2173529/200366418-ada291b7-c15a-489b-a93b-1c5e267fa3a2.png)

Alternative approaches welcome. One idea is setting a max size on the nav list (see https://github.com/pages-themes/leap-day/issues/48), but I'd prefer to avoid the scrollbar.
