### PR TITLE
Add page for 2024 annual meeting

### DIFF
--- a/annual-meetings/2024/index.md
+++ b/annual-meetings/2024/index.md
@@ -1,0 +1,27 @@
+# TRB Annual Meeting 2024
+
+[« Return to AP090 homepage](/)
+
+## Events
+
+<iframe src="https://teamup.com/ks6j7ehhydokhpfrkr?disableSidepanel=1&showMenu=0&showHeader=0&showViewSelector=0&view=md4&date=2024-01-07&zoom=0.8" style="width: 100%; height: 500px" loading="lazy" frameborder="0"></iframe>
+
+### Calendar Subscription
+
+**To make sure you don't miss any AP090 content, add a subscription to our full events list to your own calendar app!**
+
+The following iCal feed URL can be subscribed to in your own calendar application to see all AP090 events and keep them up-to-date with any changes:
+
+```text
+https://ics.teamup.com/feed/ks6j7ehhydokhpfrkr/12814110.ics
+```
+
+Or right click [this link](https://ics.teamup.com/feed/ks6j7ehhydokhpfrkr/12814110.ics) to copy the URL.
+
+Step-by-step instructions for adding the calendar subscription to your own calendar are available for:
+
+- [Apple iCal](https://calendar.teamup.com/kb/subscribe-to-teamup-icalendar-feeds/#apple-ical)
+- [Apple iPad / iPhone](https://calendar.teamup.com/kb/subscribe-to-teamup-icalendar-feeds/#apple-ipad-iphone)
+- [Google Calendar](https://calendar.teamup.com/kb/subscribe-to-teamup-icalendar-feeds/#google-calendar)
+- [Outlook (with Exchange)](https://calendar.teamup.com/kb/subscribe-to-teamup-icalendar-feeds/#outlook-with-exchange)
+- [Outlook.com](https://calendar.teamup.com/kb/subscribe-to-teamup-icalendar-feeds/#outlook-com)

--- a/index.md
+++ b/index.md
@@ -6,9 +6,12 @@ title: TRB Standing Committee on Transit Data - AP090
 
 Welcome to the website for TRB Standing Committee on Transit Data (AP090).
 
-**To stay up-to-date on committee webinars and other events, sign up as a friend via [MyTRB](https://www.mytrb.org/OnlineDirectory/Committee/Details/6433) (Press the "Become a Friend of this Committee" blue button)**
-
 The TRB Standing Committee on Transit Data focuses on the generation, processing, and emerging opportunities for integrating existing and emerging transit data streams with other transit and transit-related datasets to strengthen the entire network of information.
+
+## How to Connect
+
+- **For information on the upcoming 2024 TRB Annual Meeting, see [AP090 at the 2024 Annual Meeting](./annual-meetings/2024/)**
+- **To stay up-to-date on committee webinars and other events, sign up as a friend via [MyTRB](https://www.mytrb.org/OnlineDirectory/Committee/Details/6433) (Press the "Become a Friend of this Committee" blue button)**
 
 ## Mission
 
@@ -118,6 +121,10 @@ Data-Driven Bus Priority. November 29. Register [here](https://events.teams.micr
 ## Former Subcommittee Files
 
 Files from our predecessor entity (the TRB Joint Subcommittee on Transformative Trends in Transit Data (AP000/ABJ00)) are available [here](https://github.com/trb-transformative-transit-data/tttd/tree/master/minutes).
+
+# Annual Meetings
+
+- [AP090 at the 2024 Annual Meeting](./annual-meetings/2024/)
 
 # Members
 


### PR DESCRIPTION
- Creates a new landing page for 2024 annual meeting content, starting with an embedded calendar and subscription instructions
- Adds "Annual Meetings" section to home page
- Adds a callout for the upcoming annual meeting at the top, formatted as a list alongside the callout to join as a friend under a new "How to Connect" section

## New page

![Screenshot 2023-12-20 at 3 35 20 PM](https://github.com/trb-transformative-transit-data/tttd/assets/458494/61736ded-c71e-465c-838f-f2d9f4dea822)

## Homepage call to action

![Screenshot 2023-12-20 at 3 39 28 PM](https://github.com/trb-transformative-transit-data/tttd/assets/458494/bc1402bb-a7d4-4264-8b2f-88e92e8f382d)

## New homepage section

![Screenshot 2023-12-20 at 3 40 26 PM](https://github.com/trb-transformative-transit-data/tttd/assets/458494/0de5f143-fb05-4c52-8d20-7db1c22c3a14)
